### PR TITLE
Sync TextBoxes and Sliders for generation parameters

### DIFF
--- a/TarskyTGI/Pages/ChatPage.xaml
+++ b/TarskyTGI/Pages/ChatPage.xaml
@@ -116,33 +116,33 @@
                     <StackPanel Spacing="8">
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Context Size (n_ctx)" VerticalAlignment="Center"/>
-                            <TextBox x:Name="ctxBox" Text="2048" Width="60" BeforeTextChanging="TextBox_BeforeTextChanging" Grid.Column="1" Margin="10,0,0,0"/>
+                            <TextBox x:Name="ctxBox" Text="2048" Width="60" BeforeTextChanging="TextBox_BeforeTextChanging" TextChanged="ctxBox_TextChanged" Grid.Column="1" Margin="10,0,0,0"/>
                         </Grid>
-                        <Slider x:Name="ctxSlider" Minimum="128" Maximum="8192" Value="2048" StepFrequency="128" Margin="0,5,0,0"/>
+                        <Slider x:Name="ctxSlider" ValueChanged="ctxSlider_ValueChanged" Minimum="128" Maximum="8192" Value="2048" StepFrequency="128" Margin="0,5,0,0"/>
 
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Temperature" VerticalAlignment="Center"/>
-                            <TextBox x:Name="temperatureBox" Text="0.8" Width="60" BeforeTextChanging="TextBox2_BeforeTextChanging" Grid.Column="1" Margin="10,0,0,0"/>
+                            <TextBox x:Name="temperatureBox" Text="0.8" Width="60" BeforeTextChanging="TextBox2_BeforeTextChanging" TextChanged="temperatureBox_TextChanged" Grid.Column="1" Margin="10,0,0,0"/>
                         </Grid>
-                        <Slider x:Name="temperatureSlider" Minimum="0" Maximum="2" Value="0.8" StepFrequency="0.05" Margin="0,5,0,0"/>
+                        <Slider x:Name="temperatureSlider" ValueChanged="temperatureSlider_ValueChanged" Minimum="0" Maximum="2" Value="0.8" StepFrequency="0.05" Margin="0,5,0,0"/>
 
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Top P" VerticalAlignment="Center"/>
-                            <TextBox x:Name="toppBox" Text="0.95" Width="60" BeforeTextChanging="TextBox2_BeforeTextChanging" Grid.Column="1" Margin="10,0,0,0"/>
+                            <TextBox x:Name="toppBox" Text="0.95" Width="60" BeforeTextChanging="TextBox2_BeforeTextChanging" TextChanged="toppBox_TextChanged" Grid.Column="1" Margin="10,0,0,0"/>
                         </Grid>
-                        <Slider x:Name="toppSlider" Minimum="0" Maximum="1" Value="0.95" StepFrequency="0.01" Margin="0,5,0,0"/>
+                        <Slider x:Name="toppSlider" ValueChanged="toppSlider_ValueChanged" Minimum="0" Maximum="1" Value="0.95" StepFrequency="0.01" Margin="0,5,0,0"/>
 
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Min P" VerticalAlignment="Center"/>
-                            <TextBox x:Name="minpBox" Text="0.05" Width="60" BeforeTextChanging="TextBox2_BeforeTextChanging" Grid.Column="1" Margin="10,0,0,0"/>
+                            <TextBox x:Name="minpBox" Text="0.05" Width="60" BeforeTextChanging="TextBox2_BeforeTextChanging" TextChanged="minpBox_TextChanged" Grid.Column="1" Margin="10,0,0,0"/>
                         </Grid>
-                        <Slider x:Name="minpSlider" Minimum="0" Maximum="1" Value="0.05" StepFrequency="0.01" Margin="0,5,0,0"/>
+                        <Slider x:Name="minpSlider" ValueChanged="minpSlider_ValueChanged" Minimum="0" Maximum="1" Value="0.05" StepFrequency="0.01" Margin="0,5,0,0"/>
 
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="Typical P" VerticalAlignment="Center"/>
-                            <TextBox x:Name="typicalpBox" Text="1" Width="60" BeforeTextChanging="TextBox2_BeforeTextChanging" Grid.Column="1" Margin="10,0,0,0"/>
+                            <TextBox x:Name="typicalpBox" Text="1" Width="60" BeforeTextChanging="TextBox2_BeforeTextChanging" TextChanged="typicalpBox_TextChanged" Grid.Column="1" Margin="10,0,0,0"/>
                         </Grid>
-                        <Slider x:Name="typicalpSlider" Minimum="0" Maximum="1" Value="1" StepFrequency="0.01" Margin="0,5,0,0"/>
+                        <Slider x:Name="typicalpSlider" ValueChanged="typicalpSlider_ValueChanged" Minimum="0" Maximum="1" Value="1" StepFrequency="0.01" Margin="0,5,0,0"/>
                     </StackPanel>
                 </Expander>
 

--- a/TarskyTGI/Pages/ChatPage.xaml.cs
+++ b/TarskyTGI/Pages/ChatPage.xaml.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Windows.Media.Devices;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using WinRT.Interop;
@@ -355,6 +356,71 @@ namespace TarskyTGI
         private void ChatHistory_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             ((ListBox)sender).SelectedIndex = -1;
+        }
+
+        private void ctxBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            try
+            {
+                ctxSlider.Value = int.Parse(ctxBox.Text);
+            } catch { }
+        }
+
+        private void temperatureBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            try
+            {
+                temperatureSlider.Value = float.Parse(temperatureBox.Text);
+            } catch { }
+        }
+
+        private void toppBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            try
+            {
+                toppSlider.Value = float.Parse(toppBox.Text);
+            } catch { }
+        }
+
+        private void minpBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            try
+            {
+                minpSlider.Value = float.Parse(minpBox.Text);
+            } catch { }
+        }
+
+        private void typicalpBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            try
+            {
+                typicalpSlider.Value = float.Parse(typicalpBox.Text);
+            } catch { }
+        }
+
+        private void temperatureSlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            temperatureBox.Text = Math.Round(temperatureSlider.Value, 2).ToString();
+        }
+
+        private void ctxSlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            ctxBox.Text = ctxSlider.Value.ToString();
+        }
+
+        private void toppSlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            toppBox.Text = Math.Round(toppSlider.Value, 2).ToString();
+        }
+
+        private void minpSlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            minpBox.Text = Math.Round(minpSlider.Value, 2).ToString();
+        }
+
+        private void typicalpSlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            typicalpBox.Text = Math.Round(typicalpSlider.Value, 2).ToString();
         }
     }
 }

--- a/TarskyTGI/Pages/OpenAiPage.xaml
+++ b/TarskyTGI/Pages/OpenAiPage.xaml
@@ -95,17 +95,17 @@
                 <StackPanel Spacing="12">
                     <Grid ColumnDefinitions="*,Auto">
                         <TextBlock Text="Temperature" VerticalAlignment="Center"/>
-                        <TextBox x:Name="temperatureBox" Text="0.8" Width="64"
+                        <TextBox x:Name="temperatureBox" Text="0.8" Width="64" TextChanged="temperatureBox_TextChanged"
                                  BeforeTextChanging="TextBox2_BeforeTextChanging" Grid.Column="1"/>
                     </Grid>
-                    <Slider x:Name="temperatureSlider" Minimum="0" Maximum="2" Value="0.8" StepFrequency="0.05"/>
+                    <Slider x:Name="temperatureSlider" ValueChanged="temperatureSlider_ValueChanged" Minimum="0" Maximum="2" Value="0.8" StepFrequency="0.05"/>
 
                     <Grid ColumnDefinitions="*,Auto">
                         <TextBlock Text="Top P" VerticalAlignment="Center"/>
-                        <TextBox x:Name="toppBox" Text="0.95" Width="64"
+                        <TextBox x:Name="toppBox" Text="0.95" Width="64" TextChanged="toppBox_TextChanged"
                                  BeforeTextChanging="TextBox2_BeforeTextChanging" Grid.Column="1"/>
                     </Grid>
-                    <Slider x:Name="toppSlider" Minimum="0" Maximum="1" Value="0.95" StepFrequency="0.01"/>
+                    <Slider x:Name="toppSlider" ValueChanged="toppSlider_ValueChanged" Minimum="0" Maximum="1" Value="0.95" StepFrequency="0.01"/>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/TarskyTGI/Pages/OpenAiPage.xaml.cs
+++ b/TarskyTGI/Pages/OpenAiPage.xaml.cs
@@ -176,6 +176,32 @@ namespace TarskyTGI.Pages
         {
             ((ListBox)sender).SelectedIndex = -1;
         }
+
+        private void temperatureSlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            temperatureBox.Text = Math.Round(temperatureSlider.Value, 2).ToString();
+        }
+
+        private void toppSlider_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            toppBox.Text = Math.Round(toppSlider.Value, 2).ToString();
+        }
+
+        private void toppBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            try
+            {
+                toppSlider.Value = float.Parse(toppBox.Text);
+            } catch { }
+        }
+
+        private void temperatureBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            try
+            {
+                temperatureSlider.Value = float.Parse(temperatureBox.Text);
+            } catch { }
+        }
     }
 
     // ── Config saved to chat.json ──


### PR DESCRIPTION
Implemented two-way synchronization between TextBox and Slider controls for all generation parameters (context size, temperature, top-p, min-p, typical-p) in ChatPage and OpenAiPage. UI now updates both controls when either is changed, improving usability. Handled invalid input gracefully to prevent errors. No changes to parameter logic.